### PR TITLE
Finished appearance, added relativeOffset

### DIFF
--- a/src/AnalogClock.js
+++ b/src/AnalogClock.js
@@ -11,7 +11,7 @@ export default class AnalogClock extends Component {
     constructor(props) {
         super();
 
-        this.state = updateTime({}); 
+        this.state = updateTime(props); 
         this.styles = cssTransform(Styles, props);
     }
 
@@ -47,6 +47,7 @@ AnalogClock.propTypes = {
     }),
     width: PropTypes.number,
     gmtOffset: PropTypes.string,
+    relativeOffset: PropTypes.string,
 };
 
 AnalogClock.defaultProps = {

--- a/src/AnalogClock.js
+++ b/src/AnalogClock.js
@@ -11,13 +11,7 @@ export default class AnalogClock extends Component {
     constructor(props) {
         super();
 
-        const date = this.initializeTime(props.gmtOffset);
-        this.state = {
-            seconds: date[2],
-            minutes: date[1],
-            hour: date[0],
-        };
-
+        this.state = updateTime({}); 
         this.styles = cssTransform(Styles, props);
     }
 
@@ -34,16 +28,6 @@ export default class AnalogClock extends Component {
 
     componentWillUnmount() {
         clearInterval(this.interval);
-    }
-
-    initializeTime(gmtOffset) {
-        const now = new Date();
-        if (gmtOffset && gmtOffset !== 'undefined') {
-            const offsetNow = new Date(now.valueOf() + (parseFloat(gmtOffset) * 1000 * 60 * 60));
-            return [offsetNow.getUTCHours(), offsetNow.getUTCMinutes(), offsetNow.getUTCSeconds()];
-        } else {
-            return [now.getHours(), now.getMinutes(), now.getSeconds()];
-        }
     }
 
     render() {

--- a/src/AnalogClockLayout.js
+++ b/src/AnalogClockLayout.js
@@ -37,7 +37,7 @@ export default function AnalogClockLayout({ hour, minutes, seconds, styles }) {
             <div style={styles.center}> </div>
             <div style={styles.time}>
             {addZeroIfNeeded(hour)}:{addZeroIfNeeded(minutes)}
-            <br/>{addZeroIfNeeded(seconds)}</div>
+            <div style={styles.secondsTime}>{addZeroIfNeeded(seconds)}</div></div>
             {renderNotches(styles, seconds)}
         </div>
     );

--- a/src/styles.js
+++ b/src/styles.js
@@ -8,6 +8,7 @@ const AnalogBase = {
     height: s => s.width,
     position: 'relative',
     width: s => s.width,
+    margin: '20px',
 };
 
 const AnalogCenter = {
@@ -29,6 +30,12 @@ const DigitalTime = {
     textAlign: 'center',
     height: '100%',
     verticalAlign: 'middle',
+    fontFamily: 'monospace',
+    fontSize: '30px',
+}
+
+const DigitalSeconds = {
+    fontSize: '20px',
 }
 
 const AnalogHand = {
@@ -90,5 +97,6 @@ export default {
     smallTick: AnalogSmallTick,
     largeTick: AnalogLargeTick,
     time: DigitalTime,
+    secondsTime: DigitalSeconds,
     hiddenTicks: hiddenTicks,
 };

--- a/src/util.js
+++ b/src/util.js
@@ -13,14 +13,21 @@ export function cssTransform(styles, props) {
     }, {});
 }
 
-export function updateTime({ gmtOffset, seconds, minutes, hour }) {
+export function updateTime({ gmtOffset, relativeOffset, seconds, minutes, hour }) {
         const now = new Date();
         if (gmtOffset && gmtOffset !== 'undefined') {
+            // GMT Offset
             const offsetNow = new Date(now.valueOf() + (parseFloat(gmtOffset) * 1000 * 60 * 60));
             [seconds, minutes, hour] = [offsetNow.getUTCSeconds(), offsetNow.getUTCMinutes(), offsetNow.getUTCHours()];
             return { gmtOffset, seconds, minutes, hour };
+        } else if (relativeOffset && relativeOffset !== 'undefined'){ 
+            // Relative Offset
+            const offsetNow = new Date(now.valueOf() + (parseFloat(relativeOffset)));
+            [seconds, minutes, hour] = [offsetNow.getUTCSeconds(), offsetNow.getUTCMinutes(), offsetNow.getUTCHours()];
+            return { relativeOffset, seconds, minutes, hour };
         } else {
+            // No Offset
             [seconds, minutes, hour] = [now.getSeconds(), now.getMinutes(), now.getHours()];
-            return { gmtOffset, seconds, minutes, hour };
+            return { seconds, minutes, hour };
         }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -23,7 +23,7 @@ export function updateTime({ gmtOffset, relativeOffset, seconds, minutes, hour }
         } else if (relativeOffset && relativeOffset !== 'undefined'){ 
             // Relative Offset
             const offsetNow = new Date(now.valueOf() + (parseFloat(relativeOffset)));
-            [seconds, minutes, hour] = [offsetNow.getUTCSeconds(), offsetNow.getUTCMinutes(), offsetNow.getUTCHours()];
+            [seconds, minutes, hour] = [offsetNow.getSeconds(), offsetNow.getMinutes(), offsetNow.getHours()];
             return { relativeOffset, seconds, minutes, hour };
         } else {
             // No Offset


### PR DESCRIPTION
* Unique UpdateTime function
  * We pass the props to the first iteration of the function
* Added `relativeOffset` capability
  * You can offset a watch by X milliseconds
* Appearance
  * Distinction between (hours and minutes) and seconds
  * Put the clocks far from each other
  * The time text is in monospace
* STILL TODO
  * Put the refresh lag back to 1000 milliseconds, but syncronise it with the actual end of the second
  * Add `timeInCenter`, `time`, `hiddenTicks` for all themes
  * Add default values for the themes?