### PR TITLE
Ahead

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ prop    | default
 `width` | 400px
 `theme` | Themes.dark
 `gmtOffset` (optional)| offset of `new Date()` _(e.g. '-5.5')_
+`relativeOffset` (optional) | offset of `new Date().now()` in milliseconds _(e.g. '-2000' : -2 seconds)_
 
 ### Themes
 Theme      | Description
@@ -33,6 +34,7 @@ Theme      | Description
 `lime`     | Green base, white border
 `sherbert` | Gradient (green/pink) base, white border
 `navy`     | Gradient (blue) base, white border
+`radio`    | Like a radio clock, with the text at the center and ticks that disappear
 
 ### Scripts
 script         | description

--- a/demo/index.js
+++ b/demo/index.js
@@ -4,6 +4,7 @@ import AnalogClock, { Themes } from '../src/index';
 
 const WIDTH = 200;
 const GMTOFFSET= "+2";
+const RELATIVEOFFSET = "-1000";
 
 const Component = (
     <div>
@@ -11,6 +12,8 @@ const Component = (
         <span><AnalogClock width={WIDTH} theme={Themes.radio} /></span>
         <h2>With GMT Offset {GMTOFFSET}:</h2>
         <span><AnalogClock width={WIDTH} theme={Themes.radio} gmtOffset={GMTOFFSET} /></span>
+        <h2>With Relative Offset {RELATIVEOFFSET}ms:</h2>
+        <span><AnalogClock width={WIDTH} theme={Themes.radio} relativeOffset={RELATIVEOFFSET} /></span>
     </div>
 );
 

--- a/src/AnalogClock.js
+++ b/src/AnalogClock.js
@@ -11,6 +11,7 @@ export default class AnalogClock extends Component {
     constructor(props) {
         super();
 
+        console.log(cssTransform(Styles, props));
         this.state = updateTime(props); 
         this.styles = cssTransform(Styles, props);
     }

--- a/src/AnalogClock.js
+++ b/src/AnalogClock.js
@@ -11,7 +11,6 @@ export default class AnalogClock extends Component {
     constructor(props) {
         super();
 
-        console.log(cssTransform(Styles, props));
         this.state = updateTime(props); 
         this.styles = cssTransform(Styles, props);
     }

--- a/src/AnalogClockLayout.js
+++ b/src/AnalogClockLayout.js
@@ -6,7 +6,7 @@ function renderNotches({ smallTick, largeTick, hiddenTicks }, seconds) {
     for (let i = 0; i < 60; i++) {
         let style = Object.assign({}, i % 5 === 0 ? largeTick : smallTick, {
             transform: `translateX(-50%) translateY(-100%) rotate(${i * 6}deg)`,
-            visibility: `${i > seconds && hiddenTicks ? 'hidden' : 'visible'}`,
+            visibility: `${i > seconds && hiddenTicks.property ? 'hidden' : 'visible'}`,
         });
         notches.push(<span key={i} style={style} />);
     }

--- a/src/styles.js
+++ b/src/styles.js
@@ -86,7 +86,9 @@ const AnalogLargeTick = {
     width: 4,
 };
 
-const hiddenTicks = (s => s.theme.hiddenTicks);
+const hiddenTicks = {
+    property: s => s.theme.hiddenTicks,
+};
 
 export default {
     base: AnalogBase,

--- a/src/themes.js
+++ b/src/themes.js
@@ -6,6 +6,8 @@ export const light = {
     minutes: '#ccc',
     hour: '#000',
     tick: '#000',
+    timeInCenter: false,
+    hiddenTicks: false,
 };
 
 export const dark = {


### PR DESCRIPTION
* Changed README
  * `relativeOffset`
  * `radio` theme
* Demo
  * Added a radio clock with relative offset
  * Added `timeInCenter`, `hiddenTicks`for the `light` theme
* STILL TODO
  * Put the refresh lag back to 1000 milliseconds, but syncronise it with the actual end of the second
  * Add `timeInCenter`, `time`, `hiddenTicks` for all themes
  * Add default values for the themes?