### PR TITLE
Added sockets, improved accuracy, housecleaning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ node_modules
 demo/dist
 dist
 lib
+diff.txt
 es

--- a/demo/index.js
+++ b/demo/index.js
@@ -3,16 +3,11 @@ import ReactDOM from 'react-dom';
 import AnalogClock, { Themes } from '../src/index';
 
 const WIDTH = 200;
-const GMTOFFSET= "+2";
-const RELATIVEOFFSET = "-1000";
+const GMTOFFSET= "+4";
+const RELATIVEOFFSET = "-1500";
 
 const Component = (
     <div>
-        <span><AnalogClock width={WIDTH} theme={Themes.light} /></span>
-        <span><AnalogClock width={WIDTH} theme={Themes.radio} /></span>
-        <h2>With GMT Offset {GMTOFFSET}:</h2>
-        <span><AnalogClock width={WIDTH} theme={Themes.radio} gmtOffset={GMTOFFSET} /></span>
-        <h2>With Relative Offset {RELATIVEOFFSET}ms:</h2>
         <span><AnalogClock width={WIDTH} theme={Themes.radio} relativeOffset={RELATIVEOFFSET} /></span>
     </div>
 );

--- a/demo/server.js
+++ b/demo/server.js
@@ -2,10 +2,25 @@
 const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');
 const config = require('./webpack.config');
+const io = require('socket.io')();
+const SERVERPORT = 3001;
+const CLIENTPORT = 3000;
+
+io.on('connection', (client) => {
+  client.on('subscribeToTimer', (interval) => {
+    console.log('client is subscribing to timer with interval ', interval);
+    setInterval(() => {
+      client.emit('timer', new Date());
+    }, interval);
+  });
+});
+
+io.listen(SERVERPORT);
+console.log('Server listening on port', SERVERPORT);
 
 new WebpackDevServer(webpack(config), {
     publicPath: config.output.publicPath,
-}).listen(3000, 'localhost', err => {
+}).listen(CLIENTPORT, 'localhost', err => {
     if (err) {
         console.log(err);
     }

--- a/package.json
+++ b/package.json
@@ -84,5 +84,8 @@
   "directories": {
     "test": "tests"
   },
-  "author": ""
+  "author": "",
+  "dependencies": {
+    "socket.io": "^2.0.4"
+  }
 }

--- a/src/AnalogClock.js
+++ b/src/AnalogClock.js
@@ -6,19 +6,32 @@ import Styles from './styles';
 import { cssTransform, updateTime } from './util';
 import { dark } from './themes';
 
+import { subscribeToTimer } from './api';
+
 export default class AnalogClock extends Component {
 
     constructor(props) {
         super();
 
-        this.state = updateTime(props); 
+        this.state = updateTime(props);
         this.styles = cssTransform(Styles, props);
     }
 
     componentDidMount() {
+        subscribeToTimer((err, timestamp) => this.setState({
+            timestamp,
+        }));
+
         this.interval = setInterval(() => {
-            this.setState(updateTime(this.state));
-        }, 10);
+            this.setState((prevState) => {
+                const newState = updateTime(prevState);
+                if (prevState.seconds !== newState.seconds) {
+                    return newState;
+                } else {
+                    return prevState;
+                }
+            });
+        }, 50);
     }
     // TODO align clocks to reduce interval
 

--- a/src/AnalogClockLayout.js
+++ b/src/AnalogClockLayout.js
@@ -13,7 +13,7 @@ function renderNotches({ smallTick, largeTick, hiddenTicks }, seconds) {
     return notches;
 }
 
-export default function AnalogClockLayout({ hour, minutes, seconds, styles }) {
+export default function AnalogClockLayout({ hour, minutes, seconds, milliseconds, timestamp, styles }) {
     // +1 to center align
     const secondStyle = Object.assign({}, styles.second, {
         transform: `translateX(-50%) translateY(-100%) rotate(${seconds * 6 + 1}deg)`,
@@ -26,19 +26,24 @@ export default function AnalogClockLayout({ hour, minutes, seconds, styles }) {
     const hourStyle = Object.assign({}, styles.hour, {
         transform: `translateX(-50%) translateY(-100%) rotate(${hour * 30 + 1.5}deg)`,
     });
-    var addZeroIfNeeded = function (digit) {
-        return (digit < 10 ? '0':'') + digit.toString();
+    const addZeroIfNeeded = function (digit) {
+        return (digit < 10 ? '0' : '') + digit.toString();
     };
     return (
-        <div style={styles.base}>
-            <div data-testid="seconds" style={secondStyle}></div>
-            <div data-testid="minutes" style={minuteStyle}></div>
-            <div data-testid="hour" style={hourStyle}></div>
-            <div style={styles.center}> </div>
-            <div style={styles.time}>
-            {addZeroIfNeeded(hour)}:{addZeroIfNeeded(minutes)}
-            <div style={styles.secondsTime}>{addZeroIfNeeded(seconds)}</div></div>
-            {renderNotches(styles, seconds)}
+        <div>
+            <div style={styles.base}>
+                <div data-testid="seconds" style={secondStyle}></div>
+                <div data-testid="minutes" style={minuteStyle}></div>
+                <div data-testid="hour" style={hourStyle}></div>
+                <div style={styles.center}> </div>
+                <div style={styles.time}>
+                {addZeroIfNeeded(hour)}:{addZeroIfNeeded(minutes)}
+                    <div style={styles.secondsTime}>
+                    {addZeroIfNeeded(seconds)}:
+                    {milliseconds}</div></div>
+                {renderNotches(styles, seconds)}
+            </div>
+            <div style={styles.time}>{timestamp.toString()} </div>
         </div>
     );
 }
@@ -47,9 +52,18 @@ AnalogClockLayout.propTypes = {
     hour: PropTypes.number.isRequired,
     minutes: PropTypes.number.isRequired,
     seconds: PropTypes.number.isRequired,
+    milliseconds: PropTypes.number.isRequired,
+    timestamp: PropTypes.string.isRequired,
     styles: PropTypes.shape({
+        base: PropTypes.object.isRequired,
+        center: PropTypes.object.isRequired,
         second: PropTypes.object.isRequired,
         minute: PropTypes.object.isRequired,
         hour: PropTypes.object.isRequired,
+        smallTick: PropTypes.object.isRequired,
+        largeTick: PropTypes.object.isRequired,
+        time: PropTypes.object.isRequired,
+        secondsTime: PropTypes.object.isRequired,
+        hiddenTicks: PropTypes.object.isRequired,
     }).isRequired,
 };

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,9 @@
+import openSocket from 'socket.io-client';
+const socket = openSocket('http://localhost:3001');
+
+function subscribeToTimer(cb) {
+    socket.on('timer', timestamp => cb(null, timestamp));
+    socket.emit('subscribeToTimer', 100);
+}
+export { subscribeToTimer };
+

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,7 +1,7 @@
 const AnalogBase = {
     background: s => s.theme.background,
     backgroundSize: 'cover',
-    display:'table',
+    display: 'table',
     backgroundPosition: 'center',
     borderRadius: '100%',
     border: s => `${s.width / 20}px solid ${s.theme.border}`,
@@ -22,21 +22,6 @@ const AnalogCenter = {
     top: '50%',
     transform: 'translateX(-50%) translateY(-50%)',
 };
-
-const DigitalTime = {
-    visibility: s => (s.theme.timeInCenter ? 'visible' : 'hidden'),
-    color: s => s.theme.time,
-    display:'table-cell',
-    textAlign: 'center',
-    height: '100%',
-    verticalAlign: 'middle',
-    fontFamily: 'monospace',
-    fontSize: '30px',
-}
-
-const DigitalSeconds = {
-    fontSize: '20px',
-}
 
 const AnalogHand = {
     left: '50%',
@@ -86,6 +71,21 @@ const AnalogLargeTick = {
     width: 4,
 };
 
+const DigitalTime = {
+    visibility: s => (s.theme.timeInCenter ? 'visible' : 'hidden'),
+    color: s => s.theme.time,
+    display: 'table-cell',
+    textAlign: 'center',
+    height: '100%',
+    verticalAlign: 'middle',
+    fontFamily: 'monospace',
+    fontSize: '30px',
+};
+
+const DigitalSeconds = {
+    fontSize: '20px',
+};
+
 const hiddenTicks = {
     property: s => s.theme.hiddenTicks,
 };
@@ -100,5 +100,5 @@ export default {
     largeTick: AnalogLargeTick,
     time: DigitalTime,
     secondsTime: DigitalSeconds,
-    hiddenTicks: hiddenTicks,
+    hiddenTicks,
 };

--- a/src/themes.js
+++ b/src/themes.js
@@ -1,4 +1,10 @@
-export const light = {
+export const classicWatch = {
+    timeInCenter: false,
+    hiddenTicks: false,
+    time: '#000',
+}; // params for classic watch faces
+
+export const light = Object.assign({}, classicWatch, {
     background: '#fff',
     border: '#ececec',
     center: '#000',
@@ -6,11 +12,9 @@ export const light = {
     minutes: '#ccc',
     hour: '#000',
     tick: '#000',
-    timeInCenter: false,
-    hiddenTicks: false,
-};
+});
 
-export const dark = {
+export const dark = Object.assign({}, classicWatch, {
     background: '#000',
     border: '#000',
     center: '#fff',
@@ -18,9 +22,9 @@ export const dark = {
     minutes: '#ccc',
     hour: '#fff',
     tick: '#fff',
-};
+});
 
-export const aqua = {
+export const aqua = Object.assign({}, classicWatch, {
     background: '#eaeaea',
     border: '#3dd4c1',
     center: '#000',
@@ -28,9 +32,9 @@ export const aqua = {
     minutes: '#9c9c9c',
     hour: '#000',
     tick: '#000',
-};
+});
 
-export const lime = {
+export const lime = Object.assign({}, classicWatch, {
     background: '#a4f181',
     border: '#fff',
     center: '#ccc',
@@ -38,9 +42,9 @@ export const lime = {
     minutes: '#ccc',
     hour: '#fff',
     tick: '#fff',
-};
+});
 
-export const sherbert = {
+export const sherbert = Object.assign({}, classicWatch, {
     background: 'linear-gradient(to left, #fee , #ddefbb)',
     border: '#fff',
     center: '#fff',
@@ -48,9 +52,9 @@ export const sherbert = {
     minutes: '#ccc',
     hour: '#fff',
     tick: '#fff',
-};
+});
 
-export const navy = {
+export const navy = Object.assign({}, classicWatch, {
     background: 'linear-gradient(#2a70a0,#102d42)',
     border: '#fff',
     center: '#fff',
@@ -58,9 +62,9 @@ export const navy = {
     minutes: '#ccc',
     hour: '#fff',
     tick: '#fff',
-};
+});
 
-export const radio = {
+export const radio = Object.assign({}, classicWatch, {
     background: '#000',
     border: '#000',
     center: '#000',
@@ -71,6 +75,4 @@ export const radio = {
     timeInCenter: true,
     time: 'red',
     hiddenTicks: true,
-}
-
-// TODO add timeInCenter, time, hiddenTicks for everyone
+});

--- a/src/util.js
+++ b/src/util.js
@@ -13,21 +13,39 @@ export function cssTransform(styles, props) {
     }, {});
 }
 
-export function updateTime({ gmtOffset, relativeOffset, seconds, minutes, hour }) {
-        const now = new Date();
-        if (gmtOffset && gmtOffset !== 'undefined') {
-            // GMT Offset
-            const offsetNow = new Date(now.valueOf() + (parseFloat(gmtOffset) * 1000 * 60 * 60));
-            [seconds, minutes, hour] = [offsetNow.getUTCSeconds(), offsetNow.getUTCMinutes(), offsetNow.getUTCHours()];
-            return { gmtOffset, seconds, minutes, hour };
-        } else if (relativeOffset && relativeOffset !== 'undefined'){ 
-            // Relative Offset
-            const offsetNow = new Date(now.valueOf() + (parseFloat(relativeOffset)));
-            [seconds, minutes, hour] = [offsetNow.getSeconds(), offsetNow.getMinutes(), offsetNow.getHours()];
-            return { relativeOffset, seconds, minutes, hour };
-        } else {
-            // No Offset
-            [seconds, minutes, hour] = [now.getSeconds(), now.getMinutes(), now.getHours()];
-            return { seconds, minutes, hour };
-        }
+function convertToUTC(date) {
+    return new Date(
+        date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(),
+        date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds(),
+        date.getUTCMilliseconds()
+    );
+}
+
+export function updateTime({ gmtOffset, relativeOffset, timestamp }) {
+    // Note: timestamp as input and output is a STRING
+    const now = ((timestamp && timestamp !== 'undefined') ?
+                    new Date(timestamp)
+                    : new Date()); // Date obj of now
+    timestamp = ((timestamp && timestamp !== 'undefined') ?
+                    timestamp : now.toISOString()); // Convert to string
+    let [milliseconds, seconds, minutes, hour] = [0, 0, 0, 0];
+    let dateToDisplay = now;
+
+    if (gmtOffset && gmtOffset !== 'undefined') {
+        // GMT Offset
+        const ots = now.valueOf() + (parseFloat(gmtOffset) * 1000 * 60 * 60);
+        const offsetNow = new Date(ots);
+        dateToDisplay = convertToUTC(offsetNow);
+    } else if (relativeOffset && relativeOffset !== 'undefined') {
+        // Relative Offset
+        dateToDisplay = new Date(now.valueOf() + (parseFloat(relativeOffset)));
+    }
+
+    [milliseconds, seconds, minutes, hour] = [
+        dateToDisplay.getMilliseconds(), dateToDisplay.getSeconds(),
+        dateToDisplay.getMinutes(), dateToDisplay.getHours()];
+
+    return { milliseconds, seconds, minutes, hour,
+        relativeOffset, gmtOffset, timestamp };
+
 }


### PR DESCRIPTION
* Demo
  * Changed potential GMT offset to make things more distinct from Paris timezone
  * Kept only the radio clock with a relative offset (to sync with France Inter)
* Sockets!
  * Now the timestamps come from the server directly (instead of the computer) so that time can be syncronized between devices
  * Added a `subscrimeToTimer` function which serves as API (there is also a new api file)
  * Ports -- Web: 3000, Socket: 3001
* Accuracy
  * Since the time is updated every 50 milliseconds, we display only the clock with the earliest timestamp of the second. (See `AnalogClock` line 25).
  * Milliseconds are now taken into account and displayed, which is a way to check accuracy.
  * Changed `UpdateTime` to remove errors, and take milliseconds into account, and to reduce redudancy in code.
* Housecleaning
  * Clearer `PropTypes` declarations (see `AnalogClockLayout.js` line 51)
  * Lint has been run
  * There is now a special style type for classic watches (aka non-radio watch faces) that can be combined to other styles, so that these other styles don't have to think about it.
* STILL TODO
  * Make syncronistation between sockets clearer
  * Check and reduce lag with regard to server-client communications
  * Add default values for the themes?
  * Option to display milliseconds or not?
  * default values?